### PR TITLE
Lazy annotator init; fix CLI stdout, sentiment text handling, and testimony segmentation

### DIFF
--- a/spatio_textual/annotate.py
+++ b/spatio_textual/annotate.py
@@ -21,16 +21,23 @@ def _init_annotator():
         nlp = load_spacy_model('en_core_web_sm')
     return Annotator(nlp)
 
-_annotator = _init_annotator()
+_annotator = None
+
+
+def _get_annotator():
+    global _annotator
+    if _annotator is None:
+        _annotator = _init_annotator()
+    return _annotator
 
 
 def annotate_text(text: str, *, include_entities: bool = True, include_verbs: bool = False) -> dict:
-    return _annotator.annotate(text, include_entities=include_entities, include_verbs=include_verbs)
+    return _get_annotator().annotate(text, include_entities=include_entities, include_verbs=include_verbs)
 
 
 def annotate_texts(texts: List[str], file_id: Optional[str] = None, include_text: bool = False,
                    *, include_entities: bool = True, include_verbs: bool = False) -> List[dict]:
-    return _annotator.annotate_texts(
+    return _get_annotator().annotate_texts(
         texts, file_id=file_id, start_seg_id=1, include_text=include_text,
         include_entities=include_entities, include_verbs=include_verbs
     )
@@ -38,8 +45,9 @@ def annotate_texts(texts: List[str], file_id: Optional[str] = None, include_text
 
 def chunk_and_annotate_text(text: str, n_segments: int = 100, file_id: Optional[str] = None,
                             include_text: bool = False, *, include_entities: bool = True, include_verbs: bool = False) -> List[dict]:
-    segments = split_into_segments(text, n_segments=n_segments, nlp=_annotator.nlp)
-    return _annotator.annotate_texts(
+    annotator = _get_annotator()
+    segments = split_into_segments(text, n_segments=n_segments, nlp=annotator.nlp)
+    return annotator.annotate_texts(
         segments, file_id=file_id, start_seg_id=1, include_text=include_text,
         include_entities=include_entities, include_verbs=include_verbs
     )
@@ -47,7 +55,7 @@ def chunk_and_annotate_text(text: str, n_segments: int = 100, file_id: Optional[
 
 def chunk_and_annotate_file(path: str | Path, n_segments: int = 100, include_text: bool = False,
                             *, include_entities: bool = True, include_verbs: bool = False) -> List[dict]:
-    return _annotator.annotate_file_chunked(
+    return _get_annotator().annotate_file_chunked(
         path, n_segments=n_segments, include_text=include_text,
         include_entities=include_entities, include_verbs=include_verbs
     )
@@ -66,15 +74,16 @@ def annotate_files(inputs: Union[str, Path, Sequence[Union[str, Path]]],
     """
     if chunk:
         results: List[dict] = []
-        files = list(_annotator._resolve_input_files(inputs, glob_pattern, recursive))
+        annotator = _get_annotator()
+        files = list(annotator._resolve_input_files(inputs, glob_pattern, recursive))
         for f in files:
-            results.extend(_annotator.annotate_file_chunked(
+            results.extend(annotator.annotate_file_chunked(
                 f, n_segments=n_segments, encoding=encoding, errors=errors,
                 include_text=include_text, include_entities=include_entities, include_verbs=include_verbs
             ))
         return results
     else:
-        return _annotator.annotate_inputs(
+        return _get_annotator().annotate_inputs(
             inputs, glob_pattern=glob_pattern, recursive=recursive,
             encoding=encoding, errors=errors, include_text=include_text,
             include_entities=include_entities, include_verbs=include_verbs

--- a/spatio_textual/cli.py
+++ b/spatio_textual/cli.py
@@ -40,7 +40,7 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("-i", "--input", nargs="+", help="Files or directories (for testimony, plain text)")
     p.add_argument("--glob", default="*.txt")
     p.add_argument("--no-recursive", action="store_true")
-    p.add_argument("-o", "--output", default="-")
+    p.add_argument("-o", "--output", default="-", help="Output path, or '-' for stdout JSON")
     p.add_argument("--output-format", choices=["json","jsonl","csv","tsv"], default="json")
     p.add_argument("--include-text", action="store_true")
 
@@ -143,7 +143,7 @@ def main() -> int:
                 })
 
         # 4) Sentiment / Emotion
-        texts = [r.get("text", "") for r in ann]
+        texts = [r.get("text") if r.get("text") else seg for r, seg in zip(ann, segments)]
         if sent is not None:
             preds = sent.predict(texts)
             for r, p in zip(ann, preds):
@@ -184,12 +184,12 @@ def main() -> int:
         save_annotations([{"u": u, "v": v, "w": w} for u, v, w in edges], out, fmt="csv" if out.endswith(".csv") else "tsv")
         print(json.dumps({"edges": len(edges), "output": out}, ensure_ascii=False))
 
-    # 7) Save annotations
-    if args.output:
+    # 7) Save annotations / stdout
+    if args.output == "-":
+        print(json.dumps(results, ensure_ascii=False))
+    else:
         from .utils import save_annotations as _save
         _save(results, args.output, fmt=args.output_format)
-    else:
-        print(json.dumps(results, ensure_ascii=False))
 
     return 0
 

--- a/spatio_textual/qa.py
+++ b/spatio_textual/qa.py
@@ -84,6 +84,16 @@ class QAPair:
     a_text: str
 
 
+@dataclass
+class TestimonySegment:
+    text: str
+    role: str
+    turn_id: int
+    is_question: bool
+    is_answer: bool
+    qa_pair_id: Optional[int]
+
+
 # =========================
 # spaCy loading (lightweight)
 # =========================
@@ -283,6 +293,70 @@ def qa_from_file(path: str | Path,
                             merge_multiturn=merge_multiturn,
                             sentence_safe=sentence_safe,
                             file_id=p.stem)
+
+
+def segment_testimony(text: str,
+                      nlp: Optional[spacy.Language] = None,
+                      speaker_patterns: Optional[Dict[str, List[str]]] = None,
+                      join_continuations: bool = True,
+                      sentence_safe: bool = True) -> List[TestimonySegment]:
+    """
+    Segment testimony text into turn-level records expected by the CLI.
+    """
+    patterns = _compile_patterns(speaker_patterns or DEFAULT_SPEAKER_PATTERNS)
+    lines = [ln.rstrip("\n") for ln in text.splitlines() if ln.strip()]
+
+    labeled: List[Tuple[str, str, str]] = []
+    for ln in lines:
+        role, _, content = _detect_role(ln, patterns)
+        if content:
+            labeled.append((role, role.upper(), content))
+
+    if join_continuations and labeled:
+        merged: List[Tuple[str, str, str]] = []
+        cur = list(labeled[0])
+        for role, tag, content in labeled[1:]:
+            if role == cur[0]:
+                cur[2] = f"{cur[2]} {content}".strip()
+            else:
+                merged.append(tuple(cur))
+                cur = [role, tag, content]
+        merged.append(tuple(cur))
+        labeled = merged
+
+    if sentence_safe and labeled:
+        _nlp = nlp or _load_spacy()
+        sent_turns: List[Tuple[str, str, str]] = []
+        for role, tag, content in labeled:
+            for s in _nlp(content).sents:
+                t = s.text.strip()
+                if t:
+                    sent_turns.append((role, tag, t))
+        labeled = sent_turns
+
+    out: List[TestimonySegment] = []
+    pair_id = 0
+    pending_q = False
+    for idx, (role, _, content) in enumerate(labeled, start=1):
+        is_q = role == "interviewer" and _is_question(content)
+        if is_q:
+            pair_id += 1
+            pending_q = True
+            qid: Optional[int] = pair_id
+        elif pending_q and role != "interviewer":
+            qid = pair_id
+            pending_q = False
+        else:
+            qid = None
+        out.append(TestimonySegment(
+            text=content,
+            role=role,
+            turn_id=idx,
+            is_question=is_q,
+            is_answer=(role != "interviewer" and qid is not None),
+            qa_pair_id=qid,
+        ))
+    return out
 
 
 # =========================


### PR DESCRIPTION
### Motivation
- Prevent import-time crashes by avoiding eager loading of spaCy models when the package is imported in environments without models.
- Ensure the CLI treats `-o -` as stdout JSON and that sentiment/emotion analyzers receive the actual segment text when `--include-text` is not set.
- Restore CLI testimony-mode wiring by providing the `segment_testimony` API and a stable turn record shape expected by the CLI.

### Description
- Replace eager `_annotator = _init_annotator()` with a lazy singleton pattern (`_annotator = None` + `_get_annotator()`) and update `annotate_*` helpers to use `_get_annotator()` so importing the module no longer tries to load spaCy immediately.
- Update `cli.py` to document `-o/--output` help, treat `-o -` as stdout JSON, and change the sentiment/emotion input to `texts = [r.get("text") if r.get("text") else seg for r, seg in zip(ann, segments)]` so analyzers use real segment text.
- Add `TestimonySegment` dataclass and `segment_testimony` function to `qa.py` to produce turn-level metadata (`text`, `role`, `turn_id`, `is_question`, `is_answer`, `qa_pair_id`) used by the CLI.
- Minor wiring fixes so `python -m spatio_textual.cli --help` works without import errors from missing `segment_testimony`.

### Testing
- Ran `python -m spatio_textual.cli --help` which completed successfully.
- Ran `python -m compileall -q spatio_textual tests` which completed successfully.
- Ran `pytest -q` which failed in this environment due to missing spaCy models `en_core_web_trf` / `en_core_web_sm` (tests subfailed: 4 failed, 1 passed); this is an environment-related issue rather than a code regression.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eba1344ee88328a751009ebea2e204)